### PR TITLE
ci: fix release source integrity check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,10 @@ translations/*.ts whitespace=-trailing-space
 # trailing whitespace in reviews.
 installers/windows/** text eol=crlf whitespace=cr-at-eol
 *.bat text eol=crlf whitespace=cr-at-eol
-fonts/LICENSE.txt text eol=crlf whitespace=cr-at-eol
+
+# These imported files are intentionally stored with CRLF bytes in Git. Treat
+# them as opaque text assets so a fresh checkout is not immediately dirty.
+# This also preserves the upstream license contents byte-for-byte.
+installers/windows/.gitignore -text -eol whitespace=cr-at-eol
+installers/windows/LICENSE -text -eol whitespace=cr-at-eol
+fonts/LICENSE.txt -text -eol whitespace=cr-at-eol

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
           git submodule update --init --recursive
           test -f qwertycoin/.git
           tools/check_core_pin.sh
+          tools/check_source_tree_clean.sh
           test "$(git -C qwertycoin rev-parse HEAD)" = "$(git rev-parse HEAD:qwertycoin)"
 
       - name: Install dependencies
@@ -110,11 +111,10 @@ jobs:
       - name: Build
         run: cmake --build build/release --target qwertycoin-gui simplewallet wallet_rpc_server --parallel 2
 
-      - name: Verify build preserved the Core pin
+      - name: Verify build preserved source and Core pins
         run: |
           tools/check_core_pin.sh
-          test -z "$(git status --porcelain --untracked-files=no)"
-          test -z "$(git -C qwertycoin status --porcelain --untracked-files=no)"
+          tools/check_source_tree_clean.sh
 
       - name: Package and verify portable artifacts
         run: |
@@ -158,6 +158,7 @@ jobs:
           git submodule update --init --recursive
           test -f qwertycoin/.git
           tools/check_core_pin.sh
+          tools/check_source_tree_clean.sh
           test "$(git -C qwertycoin rev-parse HEAD)" = "$(git rev-parse HEAD:qwertycoin)"
 
       - name: Install dependencies
@@ -200,11 +201,10 @@ jobs:
           cmake --build build/release --target qwertycoin-gui simplewallet wallet_rpc_server --parallel 2
           cmake --build build/release --target deploy --parallel 1
 
-      - name: Verify build preserved the Core pin
+      - name: Verify build preserved source and Core pins
         run: |
           tools/check_core_pin.sh
-          test -z "$(git status --porcelain --untracked-files=no)"
-          test -z "$(git -C qwertycoin status --porcelain --untracked-files=no)"
+          tools/check_source_tree_clean.sh
 
       - name: Package and verify portable artifacts
         run: |
@@ -250,6 +250,7 @@ jobs:
           git submodule update --init --recursive
           test -f qwertycoin/.git
           tools/check_core_pin.sh
+          tools/check_source_tree_clean.sh
           test "$(git -C qwertycoin rev-parse HEAD)" = "$(git rev-parse HEAD:qwertycoin)"
 
       - name: Configure MSYS2
@@ -307,11 +308,10 @@ jobs:
           cmake --build build/release --target qwertycoin-gui simplewallet wallet_rpc_server --parallel 2
           cmake --build build/release --target deploy --parallel 1
 
-      - name: Verify build preserved the Core pin
+      - name: Verify build preserved source and Core pins
         run: |
           tools/check_core_pin.sh
-          test -z "$(git status --porcelain --untracked-files=no)"
-          test -z "$(git -C qwertycoin status --porcelain --untracked-files=no)"
+          tools/check_source_tree_clean.sh
 
       - name: Package and verify portable artifacts
         run: |

--- a/tools/check_core_pin.sh
+++ b/tools/check_core_pin.sh
@@ -29,8 +29,10 @@ if [[ "$remote_url" != "$expected_remote" ]]; then
   exit 1
 fi
 
-if [[ -n "$(git -C "$core_path" status --porcelain --untracked-files=normal)" ]]; then
+core_status=$(git -C "$core_path" status --porcelain --untracked-files=normal)
+if [[ -n "$core_status" ]]; then
   echo "qwertycoin submodule has local changes" >&2
+  printf '%s\n' "$core_status" >&2
   exit 1
 fi
 

--- a/tools/check_source_tree_clean.sh
+++ b/tools/check_source_tree_clean.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+status=$(git -C "$repo_root" status --porcelain --untracked-files=no)
+
+if [[ -n "$status" ]]; then
+  echo "tracked GUI source-tree changes detected:" >&2
+  printf '%s\n' "$status" >&2
+  exit 1
+fi
+
+echo "GUI source tree is clean"


### PR DESCRIPTION
## Summary

- preserve the three imported CRLF assets byte-for-byte while preventing false dirty-tree reports on fresh checkouts
- verify the GUI source tree before and after every manual platform build
- print exact GUI/Core dirty paths when an integrity guard fails

## Root cause

The first Linux release-candidate run completed the full build, then stopped before packaging because two tracked Windows installer files were reported dirty. Their Git blobs already contained CRLF bytes while `.gitattributes` also requested text normalization. A fresh Linux checkout therefore failed the tracked-source integrity guard even though neither the build nor the Core checkout changed them.

Failed diagnostic run: https://github.com/qwertycoin-org/qwertycoin-gui/actions/runs/34703941312

## Local verification

- fresh detached checkout: GUI source tree clean
- Core pin: `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`, clean
- all three affected asset/license SHA-256 values unchanged byte-for-byte
- workflow YAML parses successfully
- shell syntax checks pass
- CMake configure attempt leaves GUI and Core trees clean (local host lacks `Qt5Quick` development package; the full Linux compile already passed in the diagnostic run)

The release workflow remains manual-only. This PR does not activate push, pull-request, tag, schedule, release, or chained workflow triggers.

## Worked on by

- Alex (`nnian`)
