### PR TITLE
ci: enforce portable Linux ABI baseline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,14 @@ jobs:
     name: Linux x86_64
     needs: validate-inputs
     if: ${{ inputs.target == 'linux' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 360
     env:
       DEBIAN_FRONTEND: noninteractive
       ARTIFACT_PREFIX: ${{ inputs.release_name }}
       EXPECTED_REVISION: ${{ inputs.expected_revision }}
       CCACHE_DIR: .ccache
+      QWC_LINUX_GLIBC_CEILING: "2.35"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:

--- a/docs/RELEASE_CANDIDATE_BUILDS.md
+++ b/docs/RELEASE_CANDIDATE_BUILDS.md
@@ -14,7 +14,8 @@ under `.github/workflows-disabled/`.
 
 Each invocation builds exactly one target:
 
-- `linux` — Linux x86_64 tarball;
+- `linux` — Linux x86_64 tarball built on Ubuntu 22.04 with a
+  `GLIBC_2.35` compatibility ceiling;
 - `windows` — Windows x86_64 zip;
 - `macos` — macOS Apple Silicon tarball containing the `.app` bundle.
 
@@ -51,7 +52,8 @@ the GUI, pinned daemon, wallet CLI, wallet RPC, brand assets, fonts and licenses
 It also validates the platform runtime:
 
 - Linux recursively bundles non-glibc ELF dependencies, assigns relative
-  RPATHs and proves that no non-system library resolves outside the package;
+  RPATHs, proves that no non-system library resolves outside the package and
+  rejects every ELF object that requires a glibc symbol newer than 2.35;
 - Windows preserves the top-level Qt/dependency DLLs produced by `windeployqt`
   and requires the platform, SVG and QML modules;
 - macOS requires the Qt frameworks, Cocoa/SVG plugins and QML modules produced
@@ -59,8 +61,9 @@ It also validates the platform runtime:
   ad-hoc bundle signature.
 
 Every package contains `BUILD-INFO.txt` with GUI/Core revisions, runner
-platform and Qt version. The per-file SHA-256 manifest is verified before the
-archive is uploaded. Uploaded review artifacts expire after seven days.
+platform and Qt version. Linux also records the enforced glibc ceiling. The
+per-file SHA-256 manifest is verified before the archive is uploaded. Uploaded
+review artifacts expire after seven days.
 
 ## Signing and publication boundary
 

--- a/tools/release/package_artifacts.sh
+++ b/tools/release/package_artifacts.sh
@@ -37,6 +37,7 @@ mkdir -p "$output_dir/$artifact_name"
 artifact_dir="$output_dir/$artifact_name"
 gui_binary=""
 platform=$(uname -s)
+linux_glibc_ceiling=${QWC_LINUX_GLIBC_CEILING:-2.35}
 
 copy_if_found() {
   local name=$1
@@ -115,6 +116,7 @@ if [[ "$platform" == "Linux" && -n "$gui_binary" ]]; then
 
   QWC_RUNTIME_LIBRARY_PATH="$qt_lib_dir${QWC_RUNTIME_LIBRARY_PATH:+:$QWC_RUNTIME_LIBRARY_PATH}" \
     "$(dirname "$0")/bundle_linux_runtime.sh" "$artifact_dir"
+  "$(dirname "$0")/verify_linux_abi.sh" "$artifact_dir" "$linux_glibc_ceiling"
 fi
 
 # windeployqt places these directories next to the GUI executable. Preserve
@@ -144,6 +146,9 @@ fi
 printf 'source_revision=%s\ncore_revision=%s\nrunner_os=%s\nrunner_arch=%s\nqt_version=%s\n' \
   "$source_revision" "$core_revision" "${RUNNER_OS:-$platform}" "${RUNNER_ARCH:-unknown}" "$qt_version" \
   >"$artifact_dir/BUILD-INFO.txt"
+if [[ "$platform" == "Linux" ]]; then
+  printf 'glibc_ceiling=%s\n' "$linux_glibc_ceiling" >>"$artifact_dir/BUILD-INFO.txt"
+fi
 
 require_file() {
   local description=$1

--- a/tools/release/verify_linux_abi.sh
+++ b/tools/release/verify_linux_abi.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <artifact-directory> <maximum-glibc-version>" >&2
+  exit 64
+fi
+
+artifact_dir=$(realpath "$1")
+maximum_glibc=$2
+
+if [[ ! -d "$artifact_dir" ]]; then
+  echo "artifact directory does not exist: $artifact_dir" >&2
+  exit 1
+fi
+
+if [[ ! "$maximum_glibc" =~ ^[0-9]+([.][0-9]+)+$ ]]; then
+  echo "invalid maximum glibc version: $maximum_glibc" >&2
+  exit 64
+fi
+
+for command_name in file readelf realpath sort; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "missing Linux ABI verification command: $command_name" >&2
+    exit 1
+  fi
+done
+
+version_is_greater() {
+  local candidate=$1
+  local maximum=$2
+  local highest
+  highest=$(printf '%s\n%s\n' "$candidate" "$maximum" | LC_ALL=C sort -Vu | tail -n 1)
+  [[ "$candidate" != "$maximum" && "$highest" == "$candidate" ]]
+}
+
+violations=""
+observed_versions=""
+elf_count=0
+
+while IFS= read -r -d '' candidate; do
+  [[ "$(file -Lb "$candidate")" == ELF* ]] || continue
+  elf_count=$((elf_count + 1))
+
+  while IFS= read -r required_version; do
+    [[ -n "$required_version" ]] || continue
+    observed_versions+="$required_version"$'\n'
+    if version_is_greater "$required_version" "$maximum_glibc"; then
+      violations+="${candidate#"$artifact_dir/"}: GLIBC_$required_version"$'\n'
+    fi
+  done < <(
+    readelf --version-info "$candidate" 2>/dev/null \
+      | grep -Eo 'GLIBC_[0-9]+([.][0-9]+)+' \
+      | sed 's/^GLIBC_//' \
+      | LC_ALL=C sort -Vu \
+      || true
+  )
+done < <(find "$artifact_dir" -type f -print0)
+
+if [[ "$elf_count" -eq 0 || -z "$observed_versions" ]]; then
+  echo "no versioned Linux ELF files found in $artifact_dir" >&2
+  exit 1
+fi
+
+if [[ -n "$violations" ]]; then
+  echo "Linux artifact exceeds the GLIBC_$maximum_glibc compatibility ceiling:" >&2
+  printf '%s' "$violations" | LC_ALL=C sort -u >&2
+  exit 1
+fi
+
+highest_observed=$(printf '%s' "$observed_versions" | LC_ALL=C sort -Vu | tail -n 1)
+echo "Linux ABI verified: $elf_count ELF files, maximum GLIBC_$highest_observed (ceiling GLIBC_$maximum_glibc)"


### PR DESCRIPTION
## Summary

- build the Linux x86_64 review candidate on Ubuntu 22.04 instead of Ubuntu 24.04
- enforce a maximum `GLIBC_2.35` symbol requirement across every packaged ELF object
- record the Linux ABI ceiling in `BUILD-INFO.txt`
- document the supported review baseline

## Evidence

The first complete artifact run from Ubuntu 24.04 passed compilation, Core/source integrity, packaging and all 1,031 per-file SHA-256 checks:

https://github.com/qwertycoin-org/qwertycoin-gui/actions/runs/34705163817

Independent execution on Debian 12 (glibc 2.36) then correctly exposed that the archive was not portable: GUI, daemon and wallet binaries required `GLIBC_2.38`. The new verifier scanned 197 ELF files and identified 62 objects exceeding the proposed 2.35 ceiling. Its negative, positive and invalid-policy paths were all exercised locally.

GitHub currently lists `ubuntu-22.04` as a supported standard x64 runner. After merge, Linux must be rebuilt and the downloaded archive must execute on the Debian 12 validation host before Windows or macOS is started.

## Safety boundary

- no Core, consensus, wallet or QML code changes
- Core Gitlink remains `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`
- workflow remains `workflow_dispatch` only
- no tag, GitHub Release or public artifact publication

## Worked on by

- Alex (`nnian`)
