### PR TITLE
ci: bundle Qt Labs Platform runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
             qml-module-qtquick-controls2 qml-module-qtquick-layouts \
             qml-module-qtquick-dialogs qml-module-qtquick-window2 \
             qml-module-qtgraphicaleffects qml-module-qtmultimedia \
+            qml-module-qt-labs-platform \
             qttools5-dev-tools libqt5svg5-dev libqt5xmlpatterns5-dev
 
       - name: Restore compiler cache

--- a/docs/RELEASE_CANDIDATE_BUILDS.md
+++ b/docs/RELEASE_CANDIDATE_BUILDS.md
@@ -53,12 +53,14 @@ It also validates the platform runtime:
 
 - Linux recursively bundles non-glibc ELF dependencies, assigns relative
   RPATHs, proves that no non-system library resolves outside the package and
-  rejects every ELF object that requires a glibc symbol newer than 2.35;
+  rejects every ELF object that requires a glibc symbol newer than 2.35. Its
+  required runtime set includes the Qt Labs Platform integration used by the
+  native menu and file-dialog components;
 - Windows preserves the top-level Qt/dependency DLLs produced by `windeployqt`
-  and requires the platform, SVG and QML modules;
-- macOS requires the Qt frameworks, Cocoa/SVG plugins and QML modules produced
-  by `macdeployqt`, rejects Homebrew/runner dependency paths and verifies the
-  ad-hoc bundle signature.
+  and requires the platform, SVG, Qt Quick and Qt Labs Platform QML modules;
+- macOS requires the Qt frameworks, Cocoa/SVG plugins, Qt Quick and Qt Labs
+  Platform QML modules produced by `macdeployqt`, rejects Homebrew/runner
+  dependency paths and verifies the ad-hoc bundle signature.
 
 Every package contains `BUILD-INFO.txt` with GUI/Core revisions, runner
 platform and Qt version. Linux also records the enforced glibc ceiling. The

--- a/tools/release/package_artifacts.sh
+++ b/tools/release/package_artifacts.sh
@@ -184,6 +184,7 @@ if [[ "$platform" == "Linux" && -n "$gui_binary" ]]; then
   require_file "Qt Quick Controls 2 QML module" qml/QtQuick/Controls.2/qmldir
   require_file "Qt Quick Layouts QML module" qml/QtQuick/Layouts/qmldir
   require_file "Qt Graphical Effects QML module" qml/QtGraphicalEffects/qmldir
+  require_file "Qt Labs Platform QML module" qml/Qt/labs/platform/qmldir
   require_file "Qt runtime path configuration" qt.conf
 fi
 
@@ -196,6 +197,7 @@ if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
   require_file "Qt SVG image plugin" imageformats/qsvg.dll
   require_file "Qt Quick Controls 2 QML module" qml/QtQuick/Controls.2/qmldir
   require_file "Qt Quick Layouts QML module" qml/QtQuick/Layouts/qmldir
+  require_file "Qt Labs Platform QML module" qml/Qt/labs/platform/qmldir
 fi
 
 if [[ "$platform" == "Darwin" ]]; then
@@ -211,6 +213,7 @@ if [[ "$platform" == "Darwin" ]]; then
   require_file "macOS SVG image plugin" "$mac_bundle_relative/Contents/PlugIns/imageformats/libqsvg.dylib"
   require_file "macOS Qt Quick Controls 2 QML module" "$mac_bundle_relative/Contents/Resources/qml/QtQuick/Controls.2/qmldir"
   require_file "macOS Qt Quick Layouts QML module" "$mac_bundle_relative/Contents/Resources/qml/QtQuick/Layouts/qmldir"
+  require_file "macOS Qt Labs Platform QML module" "$mac_bundle_relative/Contents/Resources/qml/Qt/labs/platform/qmldir"
 
   codesign --verify --deep --strict "$mac_bundle"
   while IFS= read -r -d '' mach_file; do


### PR DESCRIPTION
## Summary

- install the Qt Labs Platform QML module in the Ubuntu 22.04 release job
- reject Linux, Windows and macOS candidates that omit the module required by the native menu and file-dialog components
- document the cross-platform runtime requirement

## Evidence

- the previous Ubuntu 22.04 candidate passed its `GLIBC_2.35` gate and all file hashes, but failed an independent offscreen GUI start with `module "Qt.labs.platform" is not installed`
- the downloaded candidate is confirmed to lack `qml/Qt/labs/platform/qmldir`
- shell syntax, workflow YAML, whitespace and Core-pin checks pass locally
- the workflow remains `workflow_dispatch`-only; this PR starts no Actions run

## Scope

- packaging/workflow documentation only
- no wallet, QML, Core or consensus changes
- Core remains pinned to `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`

## Worked on by

- Alex (`nnian`)
