### PR TITLE
ci: smoke-test packaged Linux GUI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,9 @@ jobs:
           cd dist
           sha256sum -c "${ARTIFACT_PREFIX}-linux-x86_64.sha256"
 
+      - name: Smoke-test packaged GUI runtime
+        run: tools/release/smoke_linux_gui.sh "dist/${ARTIFACT_PREFIX}-linux-x86_64"
+
       - name: Upload review artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/docs/RELEASE_CANDIDATE_BUILDS.md
+++ b/docs/RELEASE_CANDIDATE_BUILDS.md
@@ -55,7 +55,8 @@ It also validates the platform runtime:
   RPATHs, proves that no non-system library resolves outside the package and
   rejects every ELF object that requires a glibc symbol newer than 2.35. Its
   required runtime set includes the Qt Labs Platform integration used by the
-  native menu and file-dialog components;
+  native menu and file-dialog components. The packaged GUI must also load its
+  complete QML root cleanly with the offscreen software renderer;
 - Windows preserves the top-level Qt/dependency DLLs produced by `windeployqt`
   and requires the platform, SVG, Qt Quick and Qt Labs Platform QML modules;
 - macOS requires the Qt frameworks, Cocoa/SVG plugins, Qt Quick and Qt Labs

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -459,14 +459,24 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
     qmlRegisterType<QrCodeScanner>("moneroComponents.QRCodeScanner", 1, 0, "QRCodeScanner");
 #endif
 
+    // Context objects must outlive the QML engine. In particular, the
+    // --test-qml release smoke exits immediately after loading main.qml; if
+    // these objects are destroyed first, QML re-evaluates their bindings as
+    // null during shutdown and hides real runtime warnings in the noise.
+    OSCursor cursor;
+    OSHelper osHelper;
+    EposeManager eposeManager;
+#ifndef Q_OS_IOS
+    DaemonManager daemonManager;
+    P2PoolManager p2poolManager;
+#endif
+
     QQmlApplicationEngine engine;
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
     engine.setNetworkAccessManagerFactory(new NetworkAccessBlockingFactory);
 #endif
-    OSCursor cursor;
     engine.rootContext()->setContextProperty("globalCursor", &cursor);
-    OSHelper osHelper;
     engine.rootContext()->setContextProperty("oshelper", &osHelper);
 
     engine.addImportPath(":/fonts");
@@ -481,7 +491,6 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
 
     engine.rootContext()->setContextProperty("mainApp", &app);
 
-    EposeManager eposeManager;
     engine.rootContext()->setContextProperty("eposeManager", &eposeManager);
 
     engine.rootContext()->setContextProperty("IPC", ipc);
@@ -492,8 +501,6 @@ Verify update binary using 'shasum'-compatible (SHA256 algo) output signed by tw
 
 // Exclude daemon manager from IOS
 #ifndef Q_OS_IOS
-    DaemonManager daemonManager;
-    P2PoolManager p2poolManager;
     engine.rootContext()->setContextProperty("daemonManager", &daemonManager);
     engine.rootContext()->setContextProperty("p2poolManager", &p2poolManager);
 #endif

--- a/tools/release/smoke_linux_gui.sh
+++ b/tools/release/smoke_linux_gui.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <packaged-linux-directory>" >&2
+  exit 2
+fi
+
+artifact_dir=$(cd "$1" && pwd -P)
+gui="$artifact_dir/qwertycoin-gui"
+if [[ ! -x "$gui" ]]; then
+  echo "missing executable packaged GUI: $gui" >&2
+  exit 1
+fi
+
+temporary_root=${RUNNER_TEMP:-/tmp}
+smoke_dir=$(mktemp -d "$temporary_root/qwc-gui-smoke.XXXXXX")
+runtime_dir="$smoke_dir/runtime"
+config_dir="$smoke_dir/config"
+data_dir="$smoke_dir/data"
+log_file="$smoke_dir/qwertycoin-gui.log"
+mkdir "$runtime_dir" "$config_dir" "$data_dir"
+chmod 700 "$runtime_dir"
+
+set +e
+env \
+  XDG_RUNTIME_DIR="$runtime_dir" \
+  XDG_CONFIG_HOME="$config_dir" \
+  XDG_DATA_HOME="$data_dir" \
+  QT_QPA_PLATFORM=offscreen \
+  QT_QUICK_BACKEND=software \
+  "$gui" --test-qml >"$log_file" 2>&1
+smoke_status=$?
+set -e
+
+cat "$log_file"
+if [[ $smoke_status -ne 0 ]]; then
+  echo "packaged GUI smoke exited with status $smoke_status" >&2
+  exit 1
+fi
+
+if grep -Eiq \
+  'TypeError|ReferenceError|module .* is not installed|QQmlApplicationEngine failed|failed to load component|no root objects|cannot load library|could not load the Qt platform plugin|error while loading shared libraries' \
+  "$log_file"; then
+  echo "packaged GUI smoke reported a QML or runtime-loading error" >&2
+  exit 1
+fi
+
+echo "Packaged Linux GUI smoke verified"


### PR DESCRIPTION
## Summary

- make C++ context objects outlive the QML engine during the release smoke exit
- add a reusable Linux package smoke that loads the complete QML root with the offscreen software renderer
- fail the release job on missing QML modules, QML exceptions or runtime-loader errors

## Evidence

- the smoke rejects the previous packaged candidate because shutdown exposed EPoSe bindings after their C++ context object became null
- a normal packaged GUI start is otherwise healthy and remains running without warnings
- the corrected GUI builds locally with `DEV_MODE=OFF` and `QML_TESTS=OFF`
- the same smoke passes the corrected binary without `TypeError`, missing-module or root-object errors
- shell syntax, workflow YAML, whitespace and Core-pin checks pass locally
- the workflow remains `workflow_dispatch`-only; this PR starts no Actions run

## Scope

- QML-engine/context-object lifetime and release validation only
- no wallet, EPoSe protocol, Core or consensus behavior changes
- Core remains pinned to `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`

## Worked on by

- Alex (`nnian`)
