### PR TITLE
Fix Windows Winsock include order

### DIFF
--- a/src/daemon/DaemonManager.cpp
+++ b/src/daemon/DaemonManager.cpp
@@ -26,6 +26,12 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#if defined(_WIN32)
+// Boost.Asio requires Winsock2 to be selected before Qt can transitively include
+// windows.h (and its legacy winsock.h) through QProcess/QApplication headers.
+#include <winsock2.h>
+#endif
+
 #include "DaemonManager.h"
 #include "common/util.h"
 #include "epose/resource_policy_v2.h"


### PR DESCRIPTION
## Summary

- include `winsock2.h` before Qt headers in `DaemonManager.cpp` on Windows
- prevent Qt/QProcess from selecting legacy `winsock.h` before Boost.Asio
- preserve all non-Windows behavior and the pinned Core revision

## Evidence

- Windows Action run 34711010775 reached 342/383 objects and failed only because `WinSock.h has already been included`
- local Linux `qwertycoin-gui` target rebuild: PASS
- `git diff --check`: PASS
- Core pin remains `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`
- release workflow remains manual-only

## Worked on by

- Alex (`nnian`)