### PR TITLE
Fix Qt 5 deployment tool discovery on Windows

### DIFF
--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -51,10 +51,10 @@ if(APPLE OR (WIN32 AND NOT STATIC))
         endif()
 
     elseif(WIN32)
-        find_program(QMAKE_EXECUTABLE qmake HINTS "${_qt_bin_dir}")
-        find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
+        find_program(QMAKE_EXECUTABLE NAMES qmake qmake-qt5 HINTS "${_qt_bin_dir}")
+        find_program(WINDEPLOYQT_EXECUTABLE NAMES windeployqt windeployqt-qt5 HINTS "${_qt_bin_dir}")
         if(NOT QMAKE_EXECUTABLE OR NOT WINDEPLOYQT_EXECUTABLE)
-            message(WARNING "Deploy requires qmake.exe and windeployqt.exe (no -qt5 suffix) in ${_qt_bin_dir}")
+            message(FATAL_ERROR "Deploy requires Qt 5 qmake and windeployqt in ${_qt_bin_dir}")
         endif()
         add_custom_command(TARGET deploy POST_BUILD
                            COMMAND "${CMAKE_COMMAND}" -E env PATH="${_qt_bin_dir}" "${WINDEPLOYQT_EXECUTABLE}" "$<TARGET_FILE:qwertycoin-gui>" -no-translations -qmldir="${CMAKE_SOURCE_DIR}"


### PR DESCRIPTION
## Summary

- recognize the MSYS2 Qt 5 executable names `qmake-qt5` and `windeployqt-qt5`
- retain support for unsuffixed Qt deployment tool names
- fail during CMake configure when required Windows deployment tools are unavailable

## Evidence

- Windows Action run 34712298629 compiled and linked all 383/383 targets
- deployment failed only because MSYS2 provides `windeployqt-qt5.exe`, not `windeployqt.exe`
- official MSYS2 package file list confirms `windeployqt-qt5.exe`
- local CMake configure: PASS
- `git diff --check`: PASS
- Core pin remains `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`
- release workflow remains manual-only

## Worked on by

- Alex (`nnian`)