### PR TITLE
Fix Windows ANGLE runtime packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,6 +286,7 @@ jobs:
             mingw-w64-x86_64-qt5-quickcontrols2
             mingw-w64-x86_64-qt5-svg
             mingw-w64-x86_64-qt5-tools
+            mingw-w64-x86_64-angleproject
 
       - name: Restore compiler cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -57,7 +57,7 @@ if(APPLE OR (WIN32 AND NOT STATIC))
             message(FATAL_ERROR "Deploy requires Qt 5 qmake and windeployqt in ${_qt_bin_dir}")
         endif()
         add_custom_command(TARGET deploy POST_BUILD
-                           COMMAND "${CMAKE_COMMAND}" -E env PATH="${_qt_bin_dir}" "${WINDEPLOYQT_EXECUTABLE}" "$<TARGET_FILE:qwertycoin-gui>" -no-translations -qmldir="${CMAKE_SOURCE_DIR}"
+                           COMMAND "${CMAKE_COMMAND}" -E env PATH="${_qt_bin_dir}" "${WINDEPLOYQT_EXECUTABLE}" "$<TARGET_FILE:qwertycoin-gui>" -no-translations -no-opengl-sw -qmldir="${CMAKE_SOURCE_DIR}"
                            COMMENT "Running windeployqt..."
         )
         set(WIN_DEPLOY_DLLS

--- a/tools/release/package_artifacts.sh
+++ b/tools/release/package_artifacts.sh
@@ -193,6 +193,8 @@ if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
   require_file "Qt GUI DLL" Qt5Gui.dll
   require_file "Qt QML DLL" Qt5Qml.dll
   require_file "Qt Quick DLL" Qt5Quick.dll
+  require_file "ANGLE EGL runtime" libEGL.dll
+  require_file "ANGLE OpenGL ES runtime" libGLESv2.dll
   require_file "Qt Windows platform plugin" platforms/qwindows.dll
   require_file "Qt SVG image plugin" imageformats/qsvg.dll
   require_file "Qt Quick Controls 2 QML module" qml/QtQuick/Controls.2/qmldir


### PR DESCRIPTION
## Summary

- install the official MSYS2 ANGLE runtime required by the dynamically linked Qt 5 Windows build
- let `windeployqt-qt5` deploy ANGLE while disabling the absent software-OpenGL fallback
- fail Windows packaging unless both `libEGL.dll` and `libGLESv2.dll` are present

## Evidence

- Windows run 34713531761 compiled and linked all 383 targets successfully
- deployment then failed specifically because `libGLESv2.dll` was absent
- the MSYS2 `mingw-w64-x86_64-angleproject` package provides `libEGL.dll` and `libGLESv2.dll`
- workflow YAML parses locally
- `tools/release/package_artifacts.sh` passes `bash -n`
- local CMake configure passes with `DEV_MODE=OFF` and `MANUAL_SUBMODULES=1`
- `tools/check_core_pin.sh` passes; Core remains pinned to `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`
- release workflow remains `workflow_dispatch`-only

## Actions budget

No automatic workflow is enabled or triggered by this PR. The Windows candidate will be dispatched manually after merge.

## Worked on by

- Alex (`nnian`)
