### PR TITLE
Remove obsolete Windows runtime DLL names

### DIFF
--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -67,21 +67,15 @@ if(APPLE OR (WIN32 AND NOT STATIC))
             libboost_program_options-mt.dll
             libboost_serialization-mt.dll
             libboost_thread-mt.dll
-            libprotobuf.dll
             libbrotlicommon.dll
             libbrotlidec.dll
             libusb-1.0.dll
             zlib1.dll
             libzstd.dll
             libwinpthread-1.dll
-            libtiff-6.dll
             libstdc++-6.dll
             libpng16-16.dll
-            libpcre16-0.dll
-            libpcre-1.dll
-            libmng-2.dll
             liblzma-5.dll
-            liblcms2-2.dll
             libjpeg-8.dll
             libintl-8.dll
             libiconv-2.dll


### PR DESCRIPTION
## Summary

- remove six obsolete DLL names from the legacy Windows runtime copy list
- retain the current Core runtime DLLs and the `windeployqt`-managed Qt/ANGLE closure

## Evidence

- Windows run 34714743546 compiled and linked all 383 targets
- `windeployqt-qt5` now successfully copied `libEGL.dll` and `libGLESv2.dll`
- deployment then failed only because the copy list referenced six files absent from the installed MSYS2 package set: `libprotobuf.dll`, `libtiff-6.dll`, `libpcre16-0.dll`, `libpcre-1.dll`, `libmng-2.dll`, and `liblcms2-2.dll`
- the run's package inventory confirms those legacy packages are not installed by the current Qt/Core dependency graph
- local CMake configure passes with `DEV_MODE=OFF` and `MANUAL_SUBMODULES=1`
- workflow YAML and release shell syntax pass locally
- Core pin remains `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`
- release workflow remains `workflow_dispatch`-only

## Actions budget

No automatic workflow is enabled or triggered by this PR. Windows will be dispatched manually after merge.

## Worked on by

- Alex (`nnian`)
