### PR TITLE
Use consistent Git semantics for Windows release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,18 +246,6 @@ jobs:
           ref: ${{ inputs.expected_revision }}
           submodules: false
 
-      - name: Checkout and verify pinned Core
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$EXPECTED_REVISION"
-          git submodule sync --recursive
-          git submodule update --init --recursive
-          test -f qwertycoin/.git
-          tools/check_core_pin.sh
-          tools/check_source_tree_clean.sh
-          test "$(git -C qwertycoin rev-parse HEAD)" = "$(git rev-parse HEAD:qwertycoin)"
-
       - name: Configure MSYS2
         uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
@@ -287,6 +275,20 @@ jobs:
             mingw-w64-x86_64-qt5-svg
             mingw-w64-x86_64-qt5-tools
             mingw-w64-x86_64-angleproject
+
+      # Use the same MSYS2 Git for the recursive checkout and the post-build
+      # cleanliness check. Mixing Git-for-Windows and MSYS2 Git makes the Core
+      # tree appear modified solely because their autocrlf defaults differ.
+      - name: Checkout and verify pinned Core
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_REVISION"
+          git submodule sync --recursive
+          git submodule update --init --recursive
+          test -f qwertycoin/.git
+          tools/check_core_pin.sh
+          tools/check_source_tree_clean.sh
+          test "$(git -C qwertycoin rev-parse HEAD)" = "$(git rev-parse HEAD:qwertycoin)"
 
       - name: Restore compiler cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4


### PR DESCRIPTION
## Summary

- configure MSYS2 before recursively checking out the pinned Core on Windows
- use the same MSYS2 Git implementation for the initial and post-build cleanliness checks
- avoid false dirty-tree failures caused solely by Git-for-Windows versus MSYS2 `autocrlf` defaults

## Evidence

- Windows run 34716152290 completed all 383 build targets and the full Qt/ANGLE runtime deployment
- the post-build check then reported nearly every tracked Core text file modified while the Core SHA remained pinned
- the initial Core checkout/check ran under `C:\\Program Files\\Git\\bin\\bash.EXE`; the post-build check ran under MSYS2
- the reported pattern is a line-ending interpretation mismatch, not a build mutation
- parsed workflow order is now `actions/checkout` → `Configure MSYS2` → recursive Core checkout/check → build → post-build check
- workflow YAML parses locally and remains `workflow_dispatch`-only
- Core pin remains `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`

## Actions budget

No automatic workflow is enabled or triggered by this PR. Windows will be dispatched manually after merge.

## Worked on by

- Alex (`nnian`)
