### PR TITLE
Normalize Windows release checkout line endings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,11 @@ jobs:
       ARTIFACT_PREFIX: ${{ inputs.release_name }}
       EXPECTED_REVISION: ${{ inputs.expected_revision }}
       CCACHE_DIR: .ccache
+      # Apply before actions/checkout so Git-for-Windows and MSYS2 Git both
+      # materialize and verify the exact LF-normalized repository contents.
+      GIT_CONFIG_COUNT: "1"
+      GIT_CONFIG_KEY_0: core.autocrlf
+      GIT_CONFIG_VALUE_0: "false"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:


### PR DESCRIPTION
## Summary

- force `core.autocrlf=false` through Git's job-wide environment configuration before `actions/checkout`
- make Git-for-Windows and MSYS2 Git materialize and verify the same LF-normalized GUI and Core trees
- keep the source-cleanliness gate strict; no ignored diffs or post-checkout overwrites

## Evidence

- Windows run 34716152290 completed all 383 build targets and full Qt/ANGLE deployment, then showed a cross-Git line-ending false positive after the build
- Windows run 34717209972 reproduced the same all-text-files dirty pattern immediately after MSYS2 checkout, before any build
- the job now exports `GIT_CONFIG_COUNT=1`, `GIT_CONFIG_KEY_0=core.autocrlf`, and `GIT_CONFIG_VALUE_0=false` before `actions/checkout`
- local Git confirms that environment tuple resolves `core.autocrlf` to `false`
- workflow YAML parses locally and remains `workflow_dispatch`-only
- Core pin remains `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`

## Actions budget

No automatic workflow is enabled or triggered by this PR. Windows will be dispatched manually after merge.

## Worked on by

- Alex (`nnian`)
