### PR TITLE
build: recognize Windows QML import layout

### DIFF
--- a/tools/release/package_artifacts.sh
+++ b/tools/release/package_artifacts.sh
@@ -197,9 +197,12 @@ if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
   require_file "ANGLE OpenGL ES runtime" libGLESv2.dll
   require_file "Qt Windows platform plugin" platforms/qwindows.dll
   require_file "Qt SVG image plugin" imageformats/qsvg.dll
-  require_file "Qt Quick Controls 2 QML module" qml/QtQuick/Controls.2/qmldir
-  require_file "Qt Quick Layouts QML module" qml/QtQuick/Layouts/qmldir
-  require_file "Qt Labs Platform QML module" qml/Qt/labs/platform/qmldir
+  # windeployqt places QML imports beside the executable. Some Qt 5
+  # distributions preserve a qml/ prefix, while MSYS2's deployment tool
+  # writes the standard import roots directly into the application folder.
+  require_file "Qt Quick Controls 2 QML module" QtQuick/Controls.2/qmldir qml/QtQuick/Controls.2/qmldir
+  require_file "Qt Quick Layouts QML module" QtQuick/Layouts/qmldir qml/QtQuick/Layouts/qmldir
+  require_file "Qt Labs Platform QML module" Qt/labs/platform/qmldir qml/Qt/labs/platform/qmldir
 fi
 
 if [[ "$platform" == "Darwin" ]]; then


### PR DESCRIPTION
## Summary
- accept the standard windeployqt QML import roots beside the executable
- retain compatibility with Qt distributions that preserve a qml/ prefix
- keep all Windows Qt Quick runtime checks fail-closed

## Evidence
- Run 34717481089 compiled/deployed all 383 targets and copied Controls.2, Layouts, and Qt.labs.platform at the application root
- post-build GUI/Core clean-tree verification passed
- bash syntax and diff checks pass locally
- workflow remains workflow_dispatch-only; no automatic Actions run is introduced