### PR TITLE
build: verify complete Windows runtime imports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,10 @@ jobs:
             mingw-w64-x86_64-zeromq
             mingw-w64-x86_64-libsodium
             mingw-w64-x86_64-unbound
+            mingw-w64-x86_64-expat
+            mingw-w64-x86_64-ldns
+            mingw-w64-x86_64-md4c
+            mingw-w64-x86_64-pcre2
             mingw-w64-x86_64-hidapi
             mingw-w64-x86_64-libusb
             mingw-w64-x86_64-qt5-base

--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -84,13 +84,18 @@ if(APPLE OR (WIN32 AND NOT STATIC))
             libglib-2.0-0.dll
             libfreetype-6.dll
             libbz2-1.dll
+            libpcre2-8-0.dll
             libpcre2-16-0.dll
+            libmd4c.dll
             libhidapi-0.dll
             libdouble-conversion.dll
             libgcrypt-20.dll
             libgpg-error-0.dll
             libsodium-26.dll
             libzmq.dll
+            libunbound-8.dll
+            libldns-3.dll
+            libexpat-1.dll
             #platform files
             libgcc_s_seh-1.dll
             #openssl files

--- a/tools/release/package_artifacts.sh
+++ b/tools/release/package_artifacts.sh
@@ -205,6 +205,11 @@ if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
   require_file "Qt Quick DLL" Qt5Quick.dll
   require_file "ANGLE EGL runtime" libEGL.dll
   require_file "ANGLE OpenGL ES runtime" libGLESv2.dll
+  require_file "Unbound runtime" libunbound-8.dll
+  require_file "LDNS runtime" libldns-3.dll
+  require_file "Expat runtime" libexpat-1.dll
+  require_file "PCRE2 8-bit runtime" libpcre2-8-0.dll
+  require_file "MD4C runtime" libmd4c.dll
   require_file "Qt Windows platform plugin" platforms/qwindows.dll
   require_file "Qt SVG image plugin" imageformats/qsvg.dll
   # windeployqt places QML imports beside the executable. Some Qt 5
@@ -213,6 +218,7 @@ if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
   require_file "Qt Quick Controls 2 QML module" QtQuick/Controls.2/qmldir qml/QtQuick/Controls.2/qmldir
   require_file "Qt Quick Layouts QML module" QtQuick/Layouts/qmldir qml/QtQuick/Layouts/qmldir
   require_file "Qt Labs Platform QML module" Qt/labs/platform/qmldir qml/Qt/labs/platform/qmldir
+  "$(dirname "$0")/verify_windows_runtime.sh" "$artifact_dir"
 fi
 
 if [[ "$platform" == "Darwin" ]]; then

--- a/tools/release/verify_windows_runtime.sh
+++ b/tools/release/verify_windows_runtime.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <portable-windows-directory>" >&2
+  exit 64
+fi
+
+artifact_dir=$1
+if [[ ! -d "$artifact_dir" ]]; then
+  echo "Windows artifact directory does not exist: $artifact_dir" >&2
+  exit 1
+fi
+
+for tool in basename find objdump sed; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "Windows runtime verification requires $tool" >&2
+    exit 1
+  fi
+done
+
+declare -A provided=()
+pe_count=0
+while IFS= read -r -d '' binary; do
+  name=$(basename "$binary")
+  provided["${name,,}"]=1
+  header=$(objdump -f "$binary")
+  if [[ "$header" != *"architecture: i386:x86-64"* ]]; then
+    echo "unexpected Windows binary architecture: ${binary#"$artifact_dir"/}" >&2
+    exit 1
+  fi
+  ((pe_count += 1))
+done < <(find "$artifact_dir" -type f \( -iname '*.exe' -o -iname '*.dll' \) -print0)
+
+if (( pe_count == 0 )); then
+  echo "Windows artifact contains no PE binaries" >&2
+  exit 1
+fi
+
+is_windows_system_dll() {
+  case "$1" in
+    api-ms-win-*|ext-ms-win-*|advapi32.dll|bcrypt.dll|cfgmgr32.dll|comctl32.dll|comdlg32.dll|crypt32.dll|cryptui.dll|d3d11.dll|d3d9.dll|dbghelp.dll|dnsapi.dll|dwmapi.dll|dwrite.dll|dxgi.dll|gdi32.dll|imm32.dll|iphlpapi.dll|kernel32.dll|kernelbase.dll|mpr.dll|msvcp_win.dll|msvcrt.dll|mswsock.dll|netapi32.dll|normaliz.dll|ntdll.dll|ole32.dll|oleacc.dll|oleaut32.dll|opengl32.dll|powrprof.dll|propsys.dll|psapi.dll|rpcrt4.dll|secur32.dll|setupapi.dll|shell32.dll|shlwapi.dll|user32.dll|userenv.dll|usp10.dll|uxtheme.dll|version.dll|winhttp.dll|winmm.dll|winspool.drv|wintrust.dll|ws2_32.dll|wtsapi32.dll|wldap32.dll)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+declare -A missing=()
+while IFS= read -r -d '' binary; do
+  while IFS= read -r dependency; do
+    [[ -n "$dependency" ]] || continue
+    normalized=${dependency,,}
+    if [[ -z "${provided[$normalized]:-}" ]] && ! is_windows_system_dll "$normalized"; then
+      missing["$normalized"]=1
+      echo "unresolved Windows import: ${binary#"$artifact_dir"/} -> $dependency" >&2
+    fi
+  done < <(objdump -p "$binary" | sed -n 's/^[[:space:]]*DLL Name:[[:space:]]*//p')
+done < <(find "$artifact_dir" -type f \( -iname '*.exe' -o -iname '*.dll' \) -print0)
+
+if (( ${#missing[@]} != 0 )); then
+  echo "Windows artifact has ${#missing[@]} unresolved non-system DLL import(s)" >&2
+  exit 1
+fi
+
+echo "Windows runtime verified: $pe_count x86-64 PE files, all imports resolved"


### PR DESCRIPTION
## Summary
- package the missing Unbound, LDNS, Expat, PCRE2 8-bit, and MD4C Windows runtimes
- declare their MSYS2 packages explicitly instead of relying only on transitive installation
- recursively verify every packaged EXE/DLL is x86-64 and every non-system DLL import resolves inside the artifact

## Evidence
- Run 34719291682 passed all 383 build/deploy targets, source/Core cleanliness, packaging, hashes, and upload
- independent inspection verified 798/798 file hashes and found exactly three unresolved non-system import names in that artifact
- negative fixture reports those exact imports; completed fixture verifies 105 x86-64 PE files with zero unresolved imports
- workflow YAML, shell syntax, diff, and Core pin checks pass locally
- workflow remains workflow_dispatch-only