### PR TITLE
build: bundle macOS helper runtimes

### DIFF
--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -5,9 +5,49 @@ if(APPLE OR (WIN32 AND NOT STATIC))
 
     if(APPLE AND NOT IOS)
         find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${_qt_bin_dir}")
+
+        # Keep all shipped Qwertycoin executables inside the application bundle
+        # so they share one self-contained Frameworks directory. Passing the
+        # helper executables explicitly makes macdeployqt rewrite their
+        # third-party install names as well as the GUI's Qt dependencies.
         add_custom_command(TARGET deploy
                            POST_BUILD
-                           COMMAND "${MACDEPLOYQT_EXECUTABLE}" "$<TARGET_FILE_DIR:qwertycoin-gui>/../.." -always-overwrite -qmldir="${CMAKE_SOURCE_DIR}"
+                           COMMAND ${CMAKE_COMMAND} -E copy
+                                   "$<TARGET_FILE:daemon>"
+                                   "$<TARGET_FILE_DIR:qwertycoin-gui>/qwertycoind"
+                           COMMAND ${CMAKE_COMMAND} -E copy
+                                   "$<TARGET_FILE:simplewallet>"
+                                   "$<TARGET_FILE_DIR:qwertycoin-gui>/qwertycoin-wallet-cli"
+                           COMMAND ${CMAKE_COMMAND} -E copy
+                                   "$<TARGET_FILE:wallet_rpc_server>"
+                                   "$<TARGET_FILE_DIR:qwertycoin-gui>/qwertycoin-wallet-rpc"
+                           COMMENT "Embedding Qwertycoin daemon and wallet tools..."
+        )
+
+        # Copy Boost dylibs that macdeployqt doesn't discover on its own. Do
+        # this before macdeployqt so their install names are normalized too.
+        find_package(Boost QUIET COMPONENTS atomic container date_time)
+        set(_boost_extras Boost::atomic Boost::container Boost::date_time)
+        foreach(_tgt IN LISTS _boost_extras)
+            if(TARGET ${_tgt})
+                add_custom_command(TARGET deploy POST_BUILD
+                                   COMMAND ${CMAKE_COMMAND} -E copy
+                                   "$<TARGET_FILE:${_tgt}>"
+                                   "$<TARGET_FILE_DIR:qwertycoin-gui>/../Frameworks/"
+                                   COMMENT "Copying $<TARGET_FILE_NAME:${_tgt}>"
+                )
+            endif()
+        endforeach()
+
+        add_custom_command(TARGET deploy
+                           POST_BUILD
+                           COMMAND "${MACDEPLOYQT_EXECUTABLE}"
+                                   "$<TARGET_FILE_DIR:qwertycoin-gui>/../.."
+                                   -always-overwrite
+                                   -qmldir="${CMAKE_SOURCE_DIR}"
+                                   -executable="$<TARGET_FILE_DIR:qwertycoin-gui>/qwertycoind"
+                                   -executable="$<TARGET_FILE_DIR:qwertycoin-gui>/qwertycoin-wallet-cli"
+                                   -executable="$<TARGET_FILE_DIR:qwertycoin-gui>/qwertycoin-wallet-rpc"
                            COMMENT "Running macdeployqt..."
         )
 
@@ -25,20 +65,6 @@ if(APPLE OR (WIN32 AND NOT STATIC))
 
             )
         endif()
-
-        # Copy Boost dylibs that macdeployqt doesn't pick up
-        find_package(Boost QUIET COMPONENTS atomic container date_time)
-        set(_boost_extras Boost::atomic Boost::container Boost::date_time)
-        foreach(_tgt IN LISTS _boost_extras)
-            if(TARGET ${_tgt})
-                add_custom_command(TARGET deploy POST_BUILD
-                                   COMMAND ${CMAKE_COMMAND} -E copy
-                                   "$<TARGET_FILE:${_tgt}>"
-                                   "$<TARGET_FILE_DIR:qwertycoin-gui>/../Frameworks/"
-                                   COMMENT "Copying $<TARGET_FILE_NAME:${_tgt}>"
-                )
-            endif()
-        endforeach()
 
         # Apple Silicon requires all binaries to be codesigned
         find_program(CODESIGN_EXECUTABLE NAMES codesign)

--- a/tools/release/package_artifacts.sh
+++ b/tools/release/package_artifacts.sh
@@ -59,11 +59,17 @@ copy_bundle_if_found() {
   fi
 }
 
-copy_if_found qwertycoin-gui
-copy_if_found qwertycoind
-copy_if_found qwertycoin-wallet-cli
-copy_if_found qwertycoin-wallet-rpc
-copy_bundle_if_found
+if [[ "$platform" == "Darwin" ]]; then
+  # The macOS deploy target embeds the daemon and wallet command-line tools in
+  # the signed application bundle. Do not also ship unbundled Homebrew-linked
+  # copies beside it.
+  copy_bundle_if_found
+else
+  copy_if_found qwertycoin-gui
+  copy_if_found qwertycoind
+  copy_if_found qwertycoin-wallet-cli
+  copy_if_found qwertycoin-wallet-rpc
+fi
 
 cp README.md "$output_dir/$artifact_name/" 2>/dev/null || true
 cp LICENSE "$output_dir/$artifact_name/" 2>/dev/null || true
@@ -174,9 +180,11 @@ require_file() {
 }
 
 require_file "GUI binary or app bundle" qwertycoin-gui qwertycoin-gui.exe qwertycoin-gui.app "Qwertycoin GUI.app"
-require_file "qwertycoind" qwertycoind qwertycoind.exe
-require_file "wallet CLI" qwertycoin-wallet-cli qwertycoin-wallet-cli.exe
-require_file "wallet RPC" qwertycoin-wallet-rpc qwertycoin-wallet-rpc.exe
+if [[ "$platform" != "Darwin" ]]; then
+  require_file "qwertycoind" qwertycoind qwertycoind.exe
+  require_file "wallet CLI" qwertycoin-wallet-cli qwertycoin-wallet-cli.exe
+  require_file "wallet RPC" qwertycoin-wallet-rpc qwertycoin-wallet-rpc.exe
+fi
 require_file "Archivo display font" share/qwertycoin-gui/Archivo/Archivo-Black.otf
 require_file "Archivo license" share/qwertycoin-gui/Archivo/OFL.txt
 require_file "Inter regular font" share/qwertycoin-gui/Inter/Inter-Regular.otf
@@ -235,15 +243,29 @@ if [[ "$platform" == "Darwin" ]]; then
   require_file "macOS Qt Quick Controls 2 QML module" "$mac_bundle_relative/Contents/Resources/qml/QtQuick/Controls.2/qmldir"
   require_file "macOS Qt Quick Layouts QML module" "$mac_bundle_relative/Contents/Resources/qml/QtQuick/Layouts/qmldir"
   require_file "macOS Qt Labs Platform QML module" "$mac_bundle_relative/Contents/Resources/qml/Qt/labs/platform/qmldir"
+  require_file "embedded macOS qwertycoind" "$mac_bundle_relative/Contents/MacOS/qwertycoind"
+  require_file "embedded macOS wallet CLI" "$mac_bundle_relative/Contents/MacOS/qwertycoin-wallet-cli"
+  require_file "embedded macOS wallet RPC" "$mac_bundle_relative/Contents/MacOS/qwertycoin-wallet-rpc"
 
   codesign --verify --deep --strict "$mac_bundle"
+  mac_mach_count=0
   while IFS= read -r -d '' mach_file; do
     [[ "$(file -Lb "$mach_file")" == Mach-O* ]] || continue
+    mac_mach_count=$((mac_mach_count + 1))
+    if ! lipo -archs "$mach_file" | tr ' ' '\n' | grep -qx arm64; then
+      echo "macOS bundle contains a non-arm64 Mach-O file: $mach_file" >&2
+      exit 1
+    fi
     if otool -L "$mach_file" | tail -n +2 | grep -E '/opt/homebrew|/usr/local|/Users/runner|/opt/hostedtoolcache'; then
       echo "macOS bundle contains a non-portable dependency: $mach_file" >&2
       exit 1
     fi
   done < <(find "$mac_bundle" -type f -print0)
+  if (( mac_mach_count == 0 )); then
+    echo "macOS bundle contains no Mach-O files" >&2
+    exit 1
+  fi
+  printf 'macOS runtime verified: %d arm64 Mach-O files, no runner-local dependencies\n' "$mac_mach_count"
 fi
 
 (


### PR DESCRIPTION
## Summary
- embed qwertycoind, wallet CLI, and wallet RPC in the macOS application bundle
- pass all helper executables to macdeployqt so Homebrew install names are rewritten
- copy exceptional Boost libraries before deployment and sign the final self-contained bundle
- package only the signed app bundle on macOS and verify all four embedded executables
- require ARM64 Mach-O content and reject runner-local dependencies

## Evidence
- macOS run 34721887706 built all targets and preserved the exact GUI/Core pins
- its fail-closed package audit rejected /opt/homebrew dependencies in the embedded daemon
- git diff --check: PASS
- bash syntax check: PASS
- Core pin remains 09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6
- release workflow remains manual workflow_dispatch only

No Core or application-logic changes. No tag or public release.
