### PR TITLE
build: create macOS frameworks directory

### DIFF
--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -12,6 +12,8 @@ if(APPLE OR (WIN32 AND NOT STATIC))
         # third-party install names as well as the GUI's Qt dependencies.
         add_custom_command(TARGET deploy
                            POST_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E make_directory
+                                   "$<TARGET_FILE_DIR:qwertycoin-gui>/../Frameworks"
                            COMMAND ${CMAKE_COMMAND} -E copy
                                    "$<TARGET_FILE:daemon>"
                                    "$<TARGET_FILE_DIR:qwertycoin-gui>/qwertycoind"


### PR DESCRIPTION
## Summary
- create Contents/Frameworks before copying exceptional Boost runtimes

## Evidence
- run 34722707858 built all four native ARM64 targets and embedded the helpers
- deploy then failed only because the Frameworks destination did not yet exist
- git diff --check: PASS
- Core pin unchanged
- workflow remains manual-only

No Core or application-logic changes. No tag or public release.
