### PR TITLE
build: normalize macOS bundle install IDs

### DIFF
--- a/cmake/Deploy.cmake
+++ b/cmake/Deploy.cmake
@@ -68,6 +68,13 @@ if(APPLE OR (WIN32 AND NOT STATIC))
             )
         endif()
 
+        add_custom_command(TARGET deploy
+                           POST_BUILD
+                           COMMAND "${CMAKE_SOURCE_DIR}/tools/release/normalize_macos_install_ids.sh"
+                                   "$<TARGET_FILE_DIR:qwertycoin-gui>/../.."
+                           COMMENT "Normalizing macOS install IDs..."
+        )
+
         # Apple Silicon requires all binaries to be codesigned
         find_program(CODESIGN_EXECUTABLE NAMES codesign)
         if(CODESIGN_EXECUTABLE)

--- a/tools/release/normalize_macos_install_ids.sh
+++ b/tools/release/normalize_macos_install_ids.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <application-bundle>" >&2
+  exit 64
+fi
+
+bundle=$1
+if [[ ! -d "$bundle/Contents/MacOS" ]]; then
+  echo "invalid macOS application bundle: $bundle" >&2
+  exit 1
+fi
+
+for tool in file otool install_name_tool; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "required macOS deployment tool is unavailable: $tool" >&2
+    exit 1
+  }
+done
+
+normalized=0
+while IFS= read -r -d '' mach_file; do
+  [[ "$(file -Lb "$mach_file")" == Mach-O* ]] || continue
+
+  install_id=$(otool -D "$mach_file" 2>/dev/null | tail -n +2 | head -n 1 || true)
+  case "$install_id" in
+    /opt/homebrew/*|/usr/local/*|/Users/runner/*|/opt/hostedtoolcache/*)
+      install_name_tool -id "@rpath/$(basename "$mach_file")" "$mach_file"
+      normalized=$((normalized + 1))
+      ;;
+  esac
+done < <(find "$bundle" -type f -print0)
+
+printf 'Normalized %d runner-local Mach-O install IDs\n' "$normalized"


### PR DESCRIPTION
## Summary
- normalize runner-local Mach-O install IDs after macdeployqt
- perform normalization before the existing final ad-hoc bundle signature
- keep the fail-closed dependency audit unchanged

## Evidence
- run 34723142803 built and deployed all four ARM64 executables successfully
- package audit then found only a Homebrew install ID on the copied Qt virtual-keyboard plugin
- shell syntax and git diff checks: PASS
- Core pin unchanged; workflow remains manual-only

No Core or application-logic changes. No tag or public release.
