### PR TITLE
build: remove macOS runner rpaths

### DIFF
--- a/tools/release/normalize_macos_install_ids.sh
+++ b/tools/release/normalize_macos_install_ids.sh
@@ -22,6 +22,7 @@ done
 
 normalized_ids=0
 normalized_dependencies=0
+removed_rpaths=0
 while IFS= read -r -d '' mach_file; do
   [[ "$(file -Lb "$mach_file")" == Mach-O* ]] || continue
 
@@ -61,7 +62,21 @@ while IFS= read -r -d '' mach_file; do
         ;;
     esac
   done < <(otool -L "$mach_file" | tail -n +2 | sed -E 's/^[[:space:]]*([^[:space:]]+).*/\1/')
+
+  while IFS= read -r rpath; do
+    [[ -n "$rpath" ]] || continue
+    case "$rpath" in
+      /opt/homebrew/*|/usr/local/*|/Users/runner/*|/opt/hostedtoolcache/*)
+        install_name_tool -delete_rpath "$rpath" "$mach_file"
+        removed_rpaths=$((removed_rpaths + 1))
+        ;;
+    esac
+  done < <(
+    otool -l "$mach_file" |
+      awk '$1 == "cmd" && $2 == "LC_RPATH" { want_path = 1; next }
+           want_path && $1 == "path" { print $2; want_path = 0 }'
+  )
 done < <(find "$bundle" -type f -print0)
 
-printf 'Normalized %d runner-local Mach-O install IDs and %d dependencies\n' \
-  "$normalized_ids" "$normalized_dependencies"
+printf 'Normalized %d runner-local Mach-O install IDs and %d dependencies; removed %d runner-local rpaths\n' \
+  "$normalized_ids" "$normalized_dependencies" "$removed_rpaths"

--- a/tools/release/package_artifacts.sh
+++ b/tools/release/package_artifacts.sh
@@ -260,6 +260,23 @@ if [[ "$platform" == "Darwin" ]]; then
       echo "macOS bundle contains a non-portable dependency: $mach_file" >&2
       exit 1
     fi
+    if otool -l "$mach_file" |
+      awk '
+        $1 == "cmd" && $2 == "LC_RPATH" { want_path = 1; next }
+        want_path && $1 == "path" {
+          want_path = 0
+          if ($2 ~ "^/opt/homebrew/" ||
+              $2 ~ "^/usr/local/" ||
+              $2 ~ "^/Users/runner/" ||
+              $2 ~ "^/opt/hostedtoolcache/") {
+            found = 1
+          }
+        }
+        END { exit found ? 0 : 1 }
+      '; then
+      echo "macOS bundle contains a non-portable runtime search path: $mach_file" >&2
+      exit 1
+    fi
   done < <(find "$mac_bundle" -type f -print0)
   if (( mac_mach_count == 0 )); then
     echo "macOS bundle contains no Mach-O files" >&2


### PR DESCRIPTION
## Summary

- remove runner-local Homebrew and hosted-runner LC_RPATH entries during macOS bundle deployment
- reject any remaining runner-local runtime search path during artifact verification
- preserve the existing fail-closed dependency and architecture checks

## Local verification

- bash syntax checks pass for both release scripts
- LC_RPATH parser fixture passes
- Core submodule remains pinned to 09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6
- release workflow remains workflow_dispatch-only

No Core or consensus changes. This PR itself does not trigger the manual release workflow.