### PR TITLE
build: target macOS 15 for Apple Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,13 +141,15 @@ jobs:
     name: macOS Apple Silicon
     needs: validate-inputs
     if: ${{ inputs.target == 'macos' }}
-    runs-on: macos-26
+    runs-on: macos-15
     timeout-minutes: 360
     env:
       ARTIFACT_PREFIX: ${{ inputs.release_name }}
       EXPECTED_REVISION: ${{ inputs.expected_revision }}
       CCACHE_DIR: .ccache
       HOMEBREW_NO_AUTO_UPDATE: 1
+      MACOSX_DEPLOYMENT_TARGET: "15.0"
+      QWC_MACOS_MIN_VERSION: "15.0"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -195,6 +197,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DARCH=armv8-a \
             -DBUILD_64=ON \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="${QWC_MACOS_MIN_VERSION}" \
             -DMANUAL_SUBMODULES=1 \
             -DDEV_MODE=OFF \
             -DWITH_UPDATER=OFF \

--- a/docs/RELEASE_CANDIDATE_BUILDS.md
+++ b/docs/RELEASE_CANDIDATE_BUILDS.md
@@ -17,7 +17,7 @@ Each invocation builds exactly one target:
 - `linux` — Linux x86_64 tarball built on Ubuntu 22.04 with a
   `GLIBC_2.35` compatibility ceiling;
 - `windows` — Windows x86_64 zip;
-- `macos` — macOS Apple Silicon tarball containing the `.app` bundle.
+- `macos` — macOS 15+ Apple Silicon tarball containing the `.app` bundle.
 
 The request must supply the exact 40-character GUI commit SHA and a restricted
 artifact prefix. Checkout and packaging fail unless the requested GUI revision,
@@ -61,12 +61,15 @@ It also validates the platform runtime:
   and requires the platform, SVG, Qt Quick and Qt Labs Platform QML modules;
 - macOS requires the Qt frameworks, Cocoa/SVG plugins, Qt Quick and Qt Labs
   Platform QML modules produced by `macdeployqt`, rejects Homebrew/runner
-  dependency paths and verifies the ad-hoc bundle signature.
+  dependency paths and runtime search paths, verifies every bundled Mach-O is
+  ARM64 with a deployment target no newer than macOS 15, and verifies the
+  ad-hoc bundle signature.
 
 Every package contains `BUILD-INFO.txt` with GUI/Core revisions, runner
-platform and Qt version. Linux also records the enforced glibc ceiling. The
-per-file SHA-256 manifest is verified before the archive is uploaded. Uploaded
-review artifacts expire after seven days.
+platform and Qt version. Linux also records the enforced glibc ceiling; macOS
+records its enforced minimum system version. The per-file SHA-256 manifest is
+verified before the archive is uploaded. Uploaded review artifacts expire after
+seven days.
 
 ## Signing and publication boundary
 

--- a/share/Info.plist
+++ b/share/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
   <key>LSMinimumSystemVersion</key>
-  <string>10.10.0</string>
+  <string>15.0</string>
 
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
@@ -30,7 +30,7 @@
   <string>org.qwertycoin.qwertycoin-gui</string>
 
   <key>CFBundleVersion</key>
-  <string>@VERSION_LONG@</string>
+  <string>@VERSION@</string>
 
   <key>CFBundleShortVersionString</key>
   <string>@VERSION@</string>

--- a/tools/release/package_artifacts.sh
+++ b/tools/release/package_artifacts.sh
@@ -164,6 +164,12 @@ printf 'source_revision=%s\ncore_revision=%s\nrunner_os=%s\nrunner_arch=%s\nqt_v
   >"$artifact_dir/BUILD-INFO.txt"
 if [[ "$platform" == "Linux" ]]; then
   printf 'glibc_ceiling=%s\n' "$linux_glibc_ceiling" >>"$artifact_dir/BUILD-INFO.txt"
+elif [[ "$platform" == "Darwin" ]]; then
+  if [[ -z "${QWC_MACOS_MIN_VERSION:-}" ]]; then
+    echo "QWC_MACOS_MIN_VERSION is required for a macOS release package" >&2
+    exit 1
+  fi
+  printf 'macos_min_version=%s\n' "$QWC_MACOS_MIN_VERSION" >>"$artifact_dir/BUILD-INFO.txt"
 fi
 
 require_file() {
@@ -247,6 +253,40 @@ if [[ "$platform" == "Darwin" ]]; then
   require_file "embedded macOS wallet CLI" "$mac_bundle_relative/Contents/MacOS/qwertycoin-wallet-cli"
   require_file "embedded macOS wallet RPC" "$mac_bundle_relative/Contents/MacOS/qwertycoin-wallet-rpc"
 
+  macos_version_exceeds() {
+    local candidate=$1
+    local ceiling=$2
+    local candidate_major=0 candidate_minor=0 candidate_patch=0
+    local ceiling_major=0 ceiling_minor=0 ceiling_patch=0
+
+    IFS=. read -r candidate_major candidate_minor candidate_patch <<<"$candidate"
+    IFS=. read -r ceiling_major ceiling_minor ceiling_patch <<<"$ceiling"
+    candidate_minor=${candidate_minor:-0}
+    candidate_patch=${candidate_patch:-0}
+    ceiling_minor=${ceiling_minor:-0}
+    ceiling_patch=${ceiling_patch:-0}
+
+    (( 10#$candidate_major > 10#$ceiling_major ||
+       (10#$candidate_major == 10#$ceiling_major && 10#$candidate_minor > 10#$ceiling_minor) ||
+       (10#$candidate_major == 10#$ceiling_major && 10#$candidate_minor == 10#$ceiling_minor && 10#$candidate_patch > 10#$ceiling_patch) ))
+  }
+
+  bundle_info_plist="$mac_bundle/Contents/Info.plist"
+  bundle_min_version=$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$bundle_info_plist")
+  bundle_build_version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$bundle_info_plist")
+  if [[ ! "$bundle_min_version" =~ ^[0-9]+([.][0-9]+){0,2}$ ]]; then
+    echo "macOS bundle has an invalid minimum system version: $bundle_min_version" >&2
+    exit 1
+  fi
+  if [[ "$bundle_min_version" != "$QWC_MACOS_MIN_VERSION" ]]; then
+    echo "macOS bundle minimum version does not match the release target: $bundle_min_version" >&2
+    exit 1
+  fi
+  if [[ ! "$bundle_build_version" =~ ^[0-9]+([.][0-9]+){0,2}$ ]]; then
+    echo "macOS bundle has an invalid CFBundleVersion: $bundle_build_version" >&2
+    exit 1
+  fi
+
   codesign --verify --deep --strict "$mac_bundle"
   mac_mach_count=0
   while IFS= read -r -d '' mach_file; do
@@ -277,12 +317,38 @@ if [[ "$platform" == "Darwin" ]]; then
       echo "macOS bundle contains a non-portable runtime search path: $mach_file" >&2
       exit 1
     fi
+    mach_min_version_count=0
+    while IFS= read -r mach_min_version; do
+      [[ -n "$mach_min_version" ]] || continue
+      mach_min_version_count=$((mach_min_version_count + 1))
+      if [[ ! "$mach_min_version" =~ ^[0-9]+([.][0-9]+){0,2}$ ]]; then
+        echo "macOS bundle contains an invalid Mach-O deployment target: $mach_min_version ($mach_file)" >&2
+        exit 1
+      fi
+      if macos_version_exceeds "$mach_min_version" "$bundle_min_version"; then
+        echo "macOS bundle contains a Mach-O requiring macOS $mach_min_version above the declared $bundle_min_version minimum: $mach_file" >&2
+        exit 1
+      fi
+    done < <(
+      otool -l "$mach_file" |
+        awk '
+          $1 == "cmd" && $2 == "LC_BUILD_VERSION" { want_build_version = 1; next }
+          want_build_version && $1 == "minos" { print $2; want_build_version = 0 }
+          $1 == "cmd" && $2 == "LC_VERSION_MIN_MACOSX" { want_legacy_version = 1; next }
+          want_legacy_version && $1 == "version" { print $2; want_legacy_version = 0 }
+        '
+    )
+    if (( mach_min_version_count == 0 )); then
+      echo "macOS bundle contains a Mach-O without a deployment target: $mach_file" >&2
+      exit 1
+    fi
   done < <(find "$mac_bundle" -type f -print0)
   if (( mac_mach_count == 0 )); then
     echo "macOS bundle contains no Mach-O files" >&2
     exit 1
   fi
-  printf 'macOS runtime verified: %d arm64 Mach-O files, no runner-local dependencies\n' "$mac_mach_count"
+  printf 'macOS runtime verified: %d arm64 Mach-O files, minimum macOS %s, no runner-local dependencies\n' \
+    "$mac_mach_count" "$bundle_min_version"
 fi
 
 (


### PR DESCRIPTION
## Summary

- build Apple Silicon candidates on the official macos-15 ARM64 runner instead of macos-26
- set and record a macOS 15.0 deployment target consistently
- populate CFBundleVersion and align LSMinimumSystemVersion
- reject any bundled Mach-O whose declared minimum OS exceeds the bundle target
- document the macOS 15+ candidate boundary

## Why

Independent inspection found 43 bundled Mach-O files requiring macOS 26 while Info.plist claimed macOS 10.10. That candidate was internally consistent but not a portable current macOS release.

## Local verification

- workflow YAML and Info.plist XML parse successfully
- release shell syntax and version/parser fixtures pass
- workflow remains workflow_dispatch-only
- Core pin remains 09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6

No Core or consensus changes. This PR itself does not trigger the manual release workflow.