### PR TITLE
release: assemble verified native candidates

### DIFF
--- a/.github/workflows/assemble-release.yml
+++ b/.github/workflows/assemble-release.yml
@@ -1,0 +1,270 @@
+name: qwc/gui-assemble-draft-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release-candidate tag (for example v2.0.0-rc1)"
+        required: true
+        default: "v2.0.0-rc1"
+        type: string
+      expected_revision:
+        description: "Exact 40-character GUI source commit used by every native build"
+        required: true
+        type: string
+      linux_run_id:
+        description: "Successful qwc/gui-release-candidate Linux run ID"
+        required: true
+        type: string
+      windows_run_id:
+        description: "Successful qwc/gui-release-candidate Windows run ID"
+        required: true
+        type: string
+      macos_run_id:
+        description: "Successful qwc/gui-release-candidate macOS run ID"
+        required: true
+        type: string
+      confirmation:
+        description: "Type CREATE-DRAFT to create a private draft prerelease"
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: qwc-gui-draft-release-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  assemble-draft:
+    name: Verify candidates and create draft release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      EXPECTED_REVISION: ${{ inputs.expected_revision }}
+      LINUX_RUN_ID: ${{ inputs.linux_run_id }}
+      WINDOWS_RUN_ID: ${{ inputs.windows_run_id }}
+      MACOS_RUN_ID: ${{ inputs.macos_run_id }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      GH_TOKEN: ${{ github.token }}
+      ARTIFACT_PREFIX: qwertycoin-gui-${{ inputs.release_tag }}
+      LINUX_ARTIFACT: qwertycoin-gui-${{ inputs.release_tag }}-linux-x86_64
+      WINDOWS_ARTIFACT: qwertycoin-gui-${{ inputs.release_tag }}-windows-x86_64
+      MACOS_ARTIFACT: qwertycoin-gui-${{ inputs.release_tag }}-macos-arm64
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate immutable release request
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]
+          [[ "$EXPECTED_REVISION" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$LINUX_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$WINDOWS_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$MACOS_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          test "$CONFIRMATION" = CREATE-DRAFT
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          git cat-file -e "${EXPECTED_REVISION}^{commit}"
+          git merge-base --is-ancestor "$EXPECTED_REVISION" "$GITHUB_SHA"
+          core_revision=$(git rev-parse "${EXPECTED_REVISION}:qwertycoin")
+          [[ "$core_revision" =~ ^[0-9a-f]{40}$ ]]
+          test "$ARTIFACT_PREFIX" = "qwertycoin-gui-${RELEASE_TAG}"
+          echo "CORE_REVISION=$core_revision" >> "$GITHUB_ENV"
+
+      - name: Validate native build runs and artifact identities
+        shell: bash
+        run: |
+          set -euo pipefail
+          validate_run() {
+            local run_id=$1 artifact_name=$2 job_name=$3
+            run=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}")
+            jq -e \
+              --arg revision "$EXPECTED_REVISION" \
+              '.name == "qwc/gui-release-candidate"
+               and .path == ".github/workflows/release.yml"
+               and .event == "workflow_dispatch"
+               and .head_branch == "master"
+               and .head_sha == $revision
+               and .status == "completed"
+               and .conclusion == "success"
+               and .run_attempt == 1' <<<"$run" >/dev/null
+
+            jobs=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?per_page=100")
+            jq -e --arg job "$job_name" \
+              'any(.jobs[]; .name == $job and .status == "completed" and .conclusion == "success")' \
+              <<<"$jobs" >/dev/null
+
+            artifacts=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100")
+            jq -e --arg name "$artifact_name" \
+              '[.artifacts[] | select(.name == $name and .expired == false)] | length == 1' \
+              <<<"$artifacts" >/dev/null
+          }
+          validate_run "$LINUX_RUN_ID" "$LINUX_ARTIFACT" "Linux x86_64"
+          validate_run "$WINDOWS_RUN_ID" "$WINDOWS_ARTIFACT" "Windows x86_64"
+          validate_run "$MACOS_RUN_ID" "$MACOS_ARTIFACT" "macOS Apple Silicon"
+
+      - name: Self-test archive verifier
+        shell: bash
+        run: python3 -m unittest tools/release/tests/test_verify_candidate_archive.py
+
+      - name: Download Linux candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ env.LINUX_ARTIFACT }}
+          path: incoming/linux
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.linux_run_id }}
+
+      - name: Download Windows candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ env.WINDOWS_ARTIFACT }}
+          path: incoming/windows
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.windows_run_id }}
+
+      - name: Download macOS candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ env.MACOS_ARTIFACT }}
+          path: incoming/macos
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.macos_run_id }}
+
+      - name: Safely verify and stage exact native archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir release-assets verified
+          test "$(find incoming/linux -maxdepth 1 -type f | wc -l)" -eq 2
+          test "$(find incoming/windows -maxdepth 1 -type f | wc -l)" -eq 2
+          test "$(find incoming/macos -maxdepth 1 -type f | wc -l)" -eq 2
+          test "$(find incoming/linux -mindepth 1 -maxdepth 1 | wc -l)" -eq 2
+          test "$(find incoming/windows -mindepth 1 -maxdepth 1 | wc -l)" -eq 2
+          test "$(find incoming/macos -mindepth 1 -maxdepth 1 | wc -l)" -eq 2
+          test -f "incoming/linux/${LINUX_ARTIFACT}.sha256"
+          test -f "incoming/windows/${WINDOWS_ARTIFACT}.sha256"
+          test -f "incoming/macos/${MACOS_ARTIFACT}.sha256"
+
+          tools/release/verify_candidate_archive.py \
+            --archive "incoming/linux/${LINUX_ARTIFACT}.tar.gz" \
+            --destination verified/linux \
+            --root-name "$LINUX_ARTIFACT" \
+            --platform linux \
+            --expected-source "$EXPECTED_REVISION" \
+            --expected-core "$CORE_REVISION" \
+            --expected-os Linux --expected-arch X64 --expected-qt 5.15.3 \
+            --expected-glibc-ceiling 2.35
+
+          tools/release/verify_candidate_archive.py \
+            --archive "incoming/windows/${WINDOWS_ARTIFACT}.zip" \
+            --destination verified/windows \
+            --root-name "$WINDOWS_ARTIFACT" \
+            --platform windows \
+            --expected-source "$EXPECTED_REVISION" \
+            --expected-core "$CORE_REVISION" \
+            --expected-os Windows --expected-arch X64 --expected-qt 5.15.19
+
+          tools/release/verify_candidate_archive.py \
+            --archive "incoming/macos/${MACOS_ARTIFACT}.tar.gz" \
+            --destination verified/macos \
+            --root-name "$MACOS_ARTIFACT" \
+            --platform macos \
+            --expected-source "$EXPECTED_REVISION" \
+            --expected-core "$CORE_REVISION" \
+            --expected-os macOS --expected-arch ARM64 --expected-qt 5.15.19 \
+            --expected-macos-min-version 15.0
+
+          cmp "incoming/linux/${LINUX_ARTIFACT}.sha256" \
+            "verified/linux/${LINUX_ARTIFACT}.sha256"
+          cmp "incoming/windows/${WINDOWS_ARTIFACT}.sha256" \
+            "verified/windows/${WINDOWS_ARTIFACT}.sha256"
+          cmp "incoming/macos/${MACOS_ARTIFACT}.sha256" \
+            "verified/macos/${MACOS_ARTIFACT}.sha256"
+
+          cp "incoming/linux/${LINUX_ARTIFACT}.tar.gz" release-assets/
+          cp "incoming/windows/${WINDOWS_ARTIFACT}.zip" release-assets/
+          cp "incoming/macos/${MACOS_ARTIFACT}.tar.gz" release-assets/
+          (cd release-assets && sha256sum "${ARTIFACT_PREFIX}"-* > SHA256SUMS)
+
+      - name: Create immutable draft release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > release-assets/RELEASE-NOTES.md <<EOF
+          # Qwertycoin GUI ${RELEASE_TAG#v}
+
+          This is an **unsigned test release candidate** assembled from three independently validated native GitHub Actions builds.
+
+          - GUI source: \`${EXPECTED_REVISION}\`
+          - Qwertycoin Core: \`${CORE_REVISION}\`
+          - Linux x86_64 run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${LINUX_RUN_ID}
+          - Windows x86_64 run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${WINDOWS_RUN_ID}
+          - macOS Apple Silicon run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${MACOS_RUN_ID}
+
+          Compatibility targets:
+
+          - Linux x86_64: GLIBC 2.35 ceiling
+          - Windows x86_64: portable Qt 5 runtime
+          - macOS Apple Silicon: macOS 15 or newer
+
+          Signing boundary:
+
+          - Linux and Windows are unsigned.
+          - macOS is ad-hoc signed, not Developer ID signed or notarized.
+          - Verify every downloaded archive against \`SHA256SUMS\`.
+
+          The Action creates this release as a **draft prerelease**. Publication remains a separate human decision after native installation and wallet smoke testing.
+          EOF
+
+      - name: Refuse existing tag or release
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release already exists: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          test -z "$(git ls-remote --tags origin "refs/tags/${RELEASE_TAG}")"
+
+      - name: Create private draft prerelease
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "$RELEASE_TAG" \
+            release-assets/${ARTIFACT_PREFIX}-linux-x86_64.tar.gz \
+            release-assets/${ARTIFACT_PREFIX}-windows-x86_64.zip \
+            release-assets/${ARTIFACT_PREFIX}-macos-arm64.tar.gz \
+            release-assets/SHA256SUMS \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$EXPECTED_REVISION" \
+            --title "Qwertycoin GUI ${RELEASE_TAG#v} (unsigned test candidate)" \
+            --notes-file release-assets/RELEASE-NOTES.md \
+            --draft \
+            --prerelease
+
+      - name: Verify draft release metadata and assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          jq -e \
+            --arg revision "$EXPECTED_REVISION" \
+            --arg linux "${ARTIFACT_PREFIX}-linux-x86_64.tar.gz" \
+            --arg windows "${ARTIFACT_PREFIX}-windows-x86_64.zip" \
+            --arg macos "${ARTIFACT_PREFIX}-macos-arm64.tar.gz" \
+            '.draft == true
+             and .prerelease == true
+             and .target_commitish == $revision
+             and ([.assets[].name] | sort) == (["SHA256SUMS", $linux, $macos, $windows] | sort)' \
+            <<<"$release" >/dev/null
+          echo "Draft prerelease ${RELEASE_TAG} contains the three verified native archives and SHA256SUMS"

--- a/docs/RELEASE_CANDIDATE_BUILDS.md
+++ b/docs/RELEASE_CANDIDATE_BUILDS.md
@@ -84,3 +84,38 @@ Developer ID signing, Apple notarization/stapling, Windows Authenticode,
 release notes, final checksums and publication require a separate approved
 release step after native launch and wallet smoke tests on the downloaded
 artifacts.
+
+## Draft release assembly
+
+After all three downloaded candidates have been independently inspected, the
+manual-only `assemble-release.yml` workflow can assemble them into a private
+draft prerelease. The workflow does not rebuild or modify a candidate. It
+requires the exact candidate source revision, the three successful native run
+IDs and the literal confirmation `CREATE-DRAFT`.
+
+Before creating the draft, it verifies that every referenced run:
+
+- is a successful first-attempt `workflow_dispatch` execution of
+  `release.yml` on `master` at the exact requested source revision;
+- contains exactly one non-expired artifact with the expected platform name;
+- contains an archive with safe paths and links, no case-folding collisions,
+  complete matching per-file SHA-256 coverage and exact GUI/Core build metadata;
+- contains the required GUI, daemon, wallet CLI/RPC and platform runtime entry
+  points.
+
+It generates `SHA256SUMS` over the three outer release archives and creates a
+draft prerelease targeting the immutable candidate commit. Existing tags or
+releases are rejected. The draft remains private and cannot be mistaken for a
+signed stable release; publication is still a separate human decision.
+
+Example for an already reviewed candidate set:
+
+```sh
+gh workflow run assemble-release.yml --ref master \
+  -f release_tag=v2.0.0-rc1 \
+  -f expected_revision=<exact-40-character-gui-sha> \
+  -f linux_run_id=<linux-run-id> \
+  -f windows_run_id=<windows-run-id> \
+  -f macos_run_id=<macos-run-id> \
+  -f confirmation=CREATE-DRAFT
+```

--- a/tools/release/tests/test_verify_candidate_archive.py
+++ b/tools/release/tests/test_verify_candidate_archive.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "verify_candidate_archive.py"
+SPEC = spec_from_file_location("verify_candidate_archive", MODULE_PATH)
+assert SPEC and SPEC.loader
+VERIFY = module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFY)
+
+
+class ArchivePathTests(unittest.TestCase):
+    def assert_rejected(self, callback) -> None:
+        with self.assertRaises(SystemExit):
+            callback()
+
+    def test_rejects_absolute_and_traversal_paths(self) -> None:
+        self.assert_rejected(lambda: VERIFY.normalize_member("/payload"))
+        self.assert_rejected(lambda: VERIFY.normalize_member("payload/../escape"))
+        self.assert_rejected(lambda: VERIFY.normalize_member("payload\\escape"))
+
+    def test_rejects_casefold_collision(self) -> None:
+        self.assert_rejected(
+            lambda: VERIFY.validate_names(["release/File", "release/file"], "release")
+        )
+
+    def test_rejects_members_outside_expected_root(self) -> None:
+        self.assert_rejected(lambda: VERIFY.validate_names(["other/file"], "release"))
+
+    def test_accepts_only_internal_symlink_targets(self) -> None:
+        VERIFY.validate_link("release/lib/libname.so", "libname.so.1", "release")
+        self.assert_rejected(
+            lambda: VERIFY.validate_link("release/lib/libname.so", "../../../escape", "release")
+        )
+
+    def test_accepts_text_and_binary_sha256_manifest_formats(self) -> None:
+        digest = "a" * 64
+        self.assertIsNotNone(VERIFY.SHA256_LINE.fullmatch(f"{digest}  release/file"))
+        self.assertIsNotNone(VERIFY.SHA256_LINE.fullmatch(f"{digest} *release/file"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/release/verify_candidate_archive.py
+++ b/tools/release/verify_candidate_archive.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Safely extract and verify one native Qwertycoin GUI candidate archive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import stat
+import tarfile
+import zipfile
+
+
+SHA256_LINE = re.compile(r"^([0-9a-f]{64}) ([ *])(.+)$")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def normalize_member(name: str) -> str:
+    if not name or "\0" in name or "\\" in name:
+        fail(f"unsafe archive member name: {name!r}")
+    stripped = name.rstrip("/")
+    path = PurePosixPath(stripped)
+    if not stripped or path.is_absolute() or any(part in ("", ".", "..") for part in path.parts):
+        fail(f"unsafe archive member path: {name!r}")
+    return str(path)
+
+
+def require_expected_member(name: str, root_name: str) -> None:
+    if name == f"{root_name}.sha256":
+        return
+    if name != root_name and not name.startswith(f"{root_name}/"):
+        fail(f"archive member is outside the expected root: {name}")
+
+
+def validate_link(name: str, target: str, root_name: str) -> None:
+    if not target or "\0" in target or "\\" in target:
+        fail(f"unsafe symlink target for {name}: {target!r}")
+    target_path = PurePosixPath(target)
+    if target_path.is_absolute():
+        fail(f"absolute symlink target for {name}: {target}")
+
+    combined = PurePosixPath(name).parent.joinpath(target_path)
+    parts: list[str] = []
+    for part in combined.parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if not parts:
+                fail(f"symlink escapes archive root: {name} -> {target}")
+            parts.pop()
+        else:
+            parts.append(part)
+    resolved = "/".join(parts)
+    if resolved != root_name and not resolved.startswith(f"{root_name}/"):
+        fail(f"symlink escapes expected root: {name} -> {target}")
+
+
+def validate_names(names: list[str], root_name: str) -> None:
+    seen: set[str] = set()
+    casefolded: dict[str, str] = {}
+    for raw_name in names:
+        name = normalize_member(raw_name)
+        require_expected_member(name, root_name)
+        if name in seen:
+            fail(f"duplicate archive member: {name}")
+        seen.add(name)
+        folded = name.casefold()
+        if folded in casefolded and casefolded[folded] != name:
+            fail(f"case-folding archive collision: {casefolded[folded]} and {name}")
+        casefolded[folded] = name
+
+
+def extract_tar(archive: Path, destination: Path, root_name: str) -> None:
+    with tarfile.open(archive, "r:gz") as package:
+        members = package.getmembers()
+        validate_names([member.name for member in members], root_name)
+        for member in members:
+            name = normalize_member(member.name)
+            if member.islnk():
+                fail(f"hard links are not permitted in release archives: {name}")
+            if member.issym():
+                validate_link(name, member.linkname, root_name)
+            elif not (member.isfile() or member.isdir()):
+                fail(f"unsupported special archive member: {name}")
+        # Member paths, link targets and types were fully validated above.
+        # Avoid tarfile's newer filter= parameter so the verifier also works
+        # with the Python version shipped by Ubuntu 22.04 review hosts.
+        package.extractall(destination)
+
+
+def extract_zip(archive: Path, destination: Path, root_name: str) -> None:
+    with zipfile.ZipFile(archive) as package:
+        members = package.infolist()
+        validate_names([member.filename for member in members], root_name)
+        for member in members:
+            mode = member.external_attr >> 16
+            if stat.S_ISLNK(mode):
+                fail(f"symlinks are not permitted in Windows release archives: {member.filename}")
+        package.extractall(destination)
+
+
+def regular_files(root: Path) -> set[str]:
+    found: set[str] = set()
+    for directory, subdirectories, filenames in os.walk(root, followlinks=False):
+        subdirectories[:] = [
+            name for name in subdirectories if not Path(directory, name).is_symlink()
+        ]
+        for filename in filenames:
+            candidate = Path(directory, filename)
+            if stat.S_ISREG(candidate.lstat().st_mode):
+                found.add(candidate.relative_to(root.parent).as_posix())
+    return found
+
+
+def verify_manifest(destination: Path, root_name: str) -> int:
+    manifest = destination / f"{root_name}.sha256"
+    if not manifest.is_file() or manifest.is_symlink():
+        fail("candidate archive does not contain a regular SHA-256 manifest")
+
+    expected: dict[str, str] = {}
+    for line_number, line in enumerate(manifest.read_text(encoding="utf-8").splitlines(), 1):
+        match = SHA256_LINE.fullmatch(line)
+        if not match:
+            fail(f"invalid SHA-256 manifest line {line_number}")
+        digest, _mode, raw_name = match.groups()
+        name = normalize_member(raw_name)
+        if name == f"{root_name}.sha256":
+            fail("SHA-256 manifest must not hash itself")
+        require_expected_member(name, root_name)
+        if name in expected:
+            fail(f"duplicate SHA-256 manifest path: {name}")
+        expected[name] = digest
+
+    root = destination / root_name
+    if not root.is_dir() or root.is_symlink():
+        fail("candidate archive root is missing or is not a directory")
+    actual = regular_files(root)
+    if actual != set(expected):
+        missing = sorted(actual - set(expected))
+        extra = sorted(set(expected) - actual)
+        fail(f"SHA-256 manifest coverage mismatch; unhashed={missing[:3]}, absent={extra[:3]}")
+
+    for name, expected_digest in expected.items():
+        digest = hashlib.sha256((destination / name).read_bytes()).hexdigest()
+        if digest != expected_digest:
+            fail(f"SHA-256 mismatch: {name}")
+    return len(expected)
+
+
+def parse_build_info(path: Path) -> dict[str, str]:
+    if not path.is_file() or path.is_symlink():
+        fail("BUILD-INFO.txt is missing or not a regular file")
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "=" not in line:
+            fail(f"invalid BUILD-INFO line: {line!r}")
+        key, value = line.split("=", 1)
+        if not key or key in values:
+            fail(f"invalid or duplicate BUILD-INFO key: {key!r}")
+        values[key] = value
+    return values
+
+
+def require_payload(root: Path, platform: str) -> None:
+    if platform == "linux":
+        required = ["qwertycoin-gui", "qwertycoind", "qwertycoin-wallet-cli", "qwertycoin-wallet-rpc"]
+    elif platform == "windows":
+        required = [
+            "qwertycoin-gui.exe",
+            "qwertycoind.exe",
+            "qwertycoin-wallet-cli.exe",
+            "qwertycoin-wallet-rpc.exe",
+            "platforms/qwindows.dll",
+            "imageformats/qsvg.dll",
+            "QtQuick/Controls/qtquickcontrolsplugin.dll",
+            "QtQuick/Controls.2/qtquickcontrols2plugin.dll",
+            "Qt/labs/platform/qtlabsplatformplugin.dll",
+        ]
+    else:
+        required = [
+            "qwertycoin-gui.app/Contents/Info.plist",
+            "qwertycoin-gui.app/Contents/MacOS/qwertycoin-gui",
+            "qwertycoin-gui.app/Contents/MacOS/qwertycoind",
+            "qwertycoin-gui.app/Contents/MacOS/qwertycoin-wallet-cli",
+            "qwertycoin-gui.app/Contents/MacOS/qwertycoin-wallet-rpc",
+        ]
+    for relative in required:
+        candidate = root / relative
+        if not candidate.is_file() or candidate.is_symlink():
+            fail(f"required {platform} release payload is missing: {relative}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--destination", type=Path, required=True)
+    parser.add_argument("--root-name", required=True)
+    parser.add_argument("--platform", choices=("linux", "windows", "macos"), required=True)
+    parser.add_argument("--expected-source", required=True)
+    parser.add_argument("--expected-core", required=True)
+    parser.add_argument("--expected-os", required=True)
+    parser.add_argument("--expected-arch", required=True)
+    parser.add_argument("--expected-qt", required=True)
+    parser.add_argument("--expected-glibc-ceiling")
+    parser.add_argument("--expected-macos-min-version")
+    args = parser.parse_args()
+
+    if args.destination.exists():
+        fail(f"refusing to reuse extraction destination: {args.destination}")
+    args.destination.mkdir(parents=True)
+    try:
+        if args.archive.name.endswith(".tar.gz"):
+            extract_tar(args.archive, args.destination, args.root_name)
+        elif args.archive.suffix == ".zip":
+            extract_zip(args.archive, args.destination, args.root_name)
+        else:
+            fail(f"unsupported release archive type: {args.archive}")
+
+        file_count = verify_manifest(args.destination, args.root_name)
+        root = args.destination / args.root_name
+        info = parse_build_info(root / "BUILD-INFO.txt")
+        expected = {
+            "source_revision": args.expected_source,
+            "core_revision": args.expected_core,
+            "runner_os": args.expected_os,
+            "runner_arch": args.expected_arch,
+            "qt_version": args.expected_qt,
+        }
+        if args.expected_glibc_ceiling:
+            expected["glibc_ceiling"] = args.expected_glibc_ceiling
+        if args.expected_macos_min_version:
+            expected["macos_min_version"] = args.expected_macos_min_version
+        for key, value in expected.items():
+            if info.get(key) != value:
+                fail(f"BUILD-INFO mismatch for {key}: expected {value!r}, got {info.get(key)!r}")
+
+        require_payload(root, args.platform)
+        print(f"Verified {args.platform} candidate: {file_count} files, exact source/Core metadata")
+    except BaseException:
+        shutil.rmtree(args.destination, ignore_errors=True)
+        raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a manual-only, fail-closed draft release assembly workflow
- bind Linux, Windows and macOS assets to exact successful native run IDs and one immutable GUI/Core pair
- safely inspect archive paths, links, case-fold collisions, complete per-file SHA-256 coverage, BUILD-INFO and required payloads
- create outer `SHA256SUMS` and a private draft prerelease only
- document the unsigned/ad-hoc signing boundary and separate publication decision

## Exact candidate set

- GUI: `f4fd4e7eec9f5d50f10cfcd31adaf60c1a2a5aa1`
- Core: `09086f7dbaaf1a4ff16bddeaa1d729f9ff65eca6`
- Linux: https://github.com/qwertycoin-org/qwertycoin-gui/actions/runs/34726837252
- Windows: https://github.com/qwertycoin-org/qwertycoin-gui/actions/runs/34727621946
- macOS: https://github.com/qwertycoin-org/qwertycoin-gui/actions/runs/34726163362

## Local verification

- archive verifier unit tests: 5/5 PASS
- real Linux archive: 1031/1031 files PASS
- real macOS archive: 1196/1196 files PASS
- real Windows archive: 803/803 files PASS
- candidate run/job/artifact metadata simulation: PASS
- YAML parsing, embedded Bash parsing and `git diff --check`: PASS
- `actions/download-artifact` pinned to GitHub-verified v4.3.0 commit

## Safety

Both active workflows remain `workflow_dispatch` only. This workflow never rebuilds candidates, rejects existing tags/releases, and creates a private draft prerelease. It does not publish a release, update metadata, sign binaries or consume native build runners.
